### PR TITLE
Adds `__DIR__` and fixes case sensitivity issue

### DIFF
--- a/Site/Controller/Factory.php
+++ b/Site/Controller/Factory.php
@@ -9,7 +9,7 @@
  */
 namespace Site\Controller;
 
-use chippyash\Type\String\StringType;
+use Chippyash\Type\String\StringType;
 use Interop\Container\ContainerInterface;
 
 /**

--- a/Site/Controller/SecurityController.php
+++ b/Site/Controller/SecurityController.php
@@ -10,7 +10,7 @@
 namespace Site\Controller;
 
 use Site\Model\Authenticator;
-use chippyash\Type\String\StringType;
+use Chippyash\Type\String\StringType;
 use Interop\Container\ContainerInterface;
 use Site\Controller\Traits\AfterActionLoggable;
 

--- a/Site/Model/Authenticator.php
+++ b/Site/Model/Authenticator.php
@@ -9,7 +9,7 @@
  */
 namespace Site\Model;
 
-use chippyash\Type\String\StringType;
+use Chippyash\Type\String\StringType;
 
 /**
  * Demo authenticator

--- a/Site/cfg/dic.base.factory.xml
+++ b/Site/cfg/dic.base.factory.xml
@@ -8,8 +8,8 @@
     <services>
         <!-- String Type Factory -->
         <service id="stringtype.factory" 
-                 class="chippyash\Type\String\StringType"
-                 factory-class="chippyash\Type\TypeFactory"
+                 class="Chippyash\Type\String\StringType"
+                 factory-class="Chippyash\Type\TypeFactory"
                  factory-method="createString"
                  public="false"/>
 

--- a/Site/run.php
+++ b/Site/run.php
@@ -8,7 +8,7 @@
  * @copyright Ashley Kitson, 2016, UK
  * @license GPL V3+ See LICENSE.md
  */
-require '../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 use Site\Model\Environment;
 use Slimdic\Dic\Builder;

--- a/Site/run.php
+++ b/Site/run.php
@@ -8,7 +8,7 @@
  * @copyright Ashley Kitson, 2016, UK
  * @license GPL V3+ See LICENSE.md
  */
-require __DIR__.'/../vendor/autoload.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
 
 use Site\Model\Environment;
 use Slimdic\Dic\Builder;

--- a/Site/run.php
+++ b/Site/run.php
@@ -13,7 +13,7 @@ require __DIR__.'/../vendor/autoload.php';
 use Site\Model\Environment;
 use Slimdic\Dic\Builder;
 use Slimdic\Dic\ServiceContainer;
-use chippyash\Type\String\StringType;
+use Chippyash\Type\String\StringType;
 use Slim\App;
 
 //you might consider moving this to an if/case block dependent on Environment

--- a/public/index.php
+++ b/public/index.php
@@ -6,4 +6,4 @@
  * see Site/run.php for real code
  * @copyright Ashley Kitson, 2016, UK
  */
-include_once '../Site/run.php';
+include_once __DIR__.'/../Site/run.php';

--- a/public/index.php
+++ b/public/index.php
@@ -6,4 +6,4 @@
  * see Site/run.php for real code
  * @copyright Ashley Kitson, 2016, UK
  */
-include_once __DIR__.'/../Site/run.php';
+include_once dirname(__DIR__) . '/Site/run.php';


### PR DESCRIPTION
Fixes the following issues:
- Warning given was due to failed streams for `index.php` trying to required `/Site/run.php` and `run.php` trying to require the composer autoloader.
- Could not find the class due to case-sensitivity mismatch.
